### PR TITLE
fix: url regex issues related to `.`

### DIFF
--- a/gh-download
+++ b/gh-download
@@ -110,7 +110,7 @@ token=$(gh config get -h github.com oauth_token)
 # TODO: check url from clipboard
 # Parse argments from url
 # Example: https://github.com/yuler/actions/blob/3541e20e6f195a812b0e775058224a6d6f4b9fc1/ci/nodejs.yml
-regex="^https://github.com/([A-Za-z0-9_-]*)/([A-Za-z0-9_-]*)/(tree|blob)/([A-Za-z0-9_-]*)/(.*)"
+regex="^https://github.com/([A-Za-z0-9_-]*)/([A-Za-z0-9._-]*)/(tree|blob)/([A-Za-z0-9._-]*)/(.*)"
 if [[ $# == 1 ]]; then
     if [[ $1 =~ $regex ]]; then
         repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"

--- a/gh-download
+++ b/gh-download
@@ -14,6 +14,7 @@ Usage: $CLI <repo> <...paths>
 
 Arguments:
     <repo>               like: \`username/repo\`, if username is missing, it will use the gh's username
+    <url>                github url starts with https://github.com
     <...paths>           folders or files path
 
 Options:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,3 +5,6 @@
 
 # test `--outfile`
 ../gh-download yuler/actions nodejs/ci.yml --outfile .github/workflows/nodejs.yml
+
+# test `url`
+../gh-download https://github.com/mrdoob/three.js/tree/dev/examples


### PR DESCRIPTION
This PR closes #5
- Fix regex (add `.` to the repo name and branch name)
- Add new help documentation on url
- Add url test case